### PR TITLE
[Feat] 오늘의 레시피 페이지 분리 완료

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import {
   SearchLayout,
   Notifications,
   CategoryPage,
+  // TodayRecipesPage,
 } from './pages/';
 import IntroPage from './pages/intro';
 import { isStore } from './stores/stores';
@@ -56,7 +57,11 @@ const router = createBrowserRouter([
       },
       {
         path: 'main',
-        element: <MainPage />
+        element: <MainPage />,
+      },
+      {
+        path: '/오늘의 레시피',
+        element: <CategoryPage />,
       },
       {
         path: 'category/:title',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import {
 } from './pages/';
 import IntroPage from './pages/intro';
 import { isStore } from './stores/stores';
+import { TodayRecipesPage } from './pages/todayrecipes/TodayRecipesPage';
 
 const router = createBrowserRouter([
   // 루트 페이지 (메인)
@@ -62,6 +63,10 @@ const router = createBrowserRouter([
             <MainPage />
           </SetPage>
         ),
+      },
+      {
+        path: 'todayrecipes',
+        element: <TodayRecipesPage />,
       },
       {
         path: 'category/:title',

--- a/src/hooks/useInfinityCard.ts
+++ b/src/hooks/useInfinityCard.ts
@@ -29,7 +29,6 @@ export function useInifinityCard(callbackFn: (pageParam: { pageParam: number | u
     async function getUserData() {
       try {
         setIsLoading(true);
-        console.log(isLoading);
 
         const currentUser = localStorage.getItem('pocketbase_auth');
         if (currentUser === null) return;

--- a/src/pages/category/CategoryPage.tsx
+++ b/src/pages/category/CategoryPage.tsx
@@ -1,20 +1,35 @@
 import { db } from '@/api/pocketbase';
-import { Header, LargeCard } from '@/components';
+import { DefaultLoader, Header, LargeCard } from '@/components';
 import getPbImage from '@/util/data/getPBImage';
 import { useParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import {DefaultLoader} from '@/components';
-import { useInifinityCard } from '@/hooks/useInfinityCard';
+import { useEffect, useState } from 'react';
+import { RecordModel } from 'pocketbase';
+import { useInView } from 'react-intersection-observer';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+/*
+ * -------------TODO-------------
+ * - [ ] Remove abort error
+ * - [ ] fetching 상태일때 이전 데이터 그대로 렌더링 되는거 해결
+ *       근데 이게 해당 카테고리의 기존 데이터인지, 아니면 새로운 카테고리의 기존 데이터인지 구분해야함 shit
+ * - [ ] 특정 데이터만 max를 지정?
+ * - [ ]
+ * - [ ]
+ */
 
 export function CategoryPage() {
-  const {title} = useParams();
-  
-  async function getRecipeData({pageParam = 1}) {
-    if(title === "오늘의 레시피") {
-      const recordsData = await db.collection('recipes').getList(pageParam, 6, { 
-        expand: 'rating, profile', 
-        sort: '-views' });
-      return recordsData.items;
+  const { title } = useParams();
+  const { ref, inView } = useInView({ threshold: 0.7 });
+  const [userData, setUserData] = useState<RecordModel>();
+
+  const getRecipeData = async ({ pageParam = 1 }) => {
+    if (title === '오늘의 레시피') {
+      const recordsData = await db.collection('recipes').getList(pageParam, 10, {
+        expand: 'rating, profile',
+        sort: '-views',
+      });
+      return recordsData?.items;
     } else {
       const recordsData = await db.collection('recipes').getList(pageParam, 5, {
         expand: 'rating, profile',
@@ -24,9 +39,56 @@ export function CategoryPage() {
 
       return recordsData?.items;
     }
-  }
+  };
 
-  const { data, status, isFetchingNextPage, userData, ref } = useInifinityCard(getRecipeData);
+  // const getRecipeData = async ({ pageParam = 1 }) => {
+  //   switch (title) {
+  //     case title === '건강식':
+  //       console.log('건강식');
+  //       await db
+  //         .collection('recipes')
+  //         .getList(pageParam, 5, titleMap[title])
+  //         .then((data) => data.items)
+  //         .catch((err) => {
+  //           if (!err.isAbort) console.warn('non cancellation error:', err);
+  //         });
+  //   }
+  // };
+  const { data, status, isFetchingNextPage, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
+    queryKey: ['recipes'],
+    queryFn: getRecipeData,
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const nextPage = lastPage?.length ? allPages.length + 1 : undefined;
+      return nextPage;
+    },
+    // maxPages: 2,
+  });
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      console.log('isInview');
+      fetchNextPage();
+    }
+  }, [fetchNextPage, hasNextPage, inView]);
+
+  useEffect(() => {
+    async function getUserData() {
+      const currentUser = localStorage.getItem('pocketbase_auth');
+      if (currentUser === null) return;
+      const userId = JSON.parse(currentUser).model.id;
+      const response = await db.collection('users').getOne(userId, { requestKey: null });
+      if (response === undefined) return;
+      setUserData(response);
+    }
+
+    getUserData();
+    db.collection('users').subscribe('*', getUserData);
+
+    return () => {
+      db.collection('users').unsubscribe();
+    };
+  }, []);
 
   const contents = data?.pages.map((recipes) =>
     recipes?.map((recipe, index) => {
@@ -65,7 +127,6 @@ export function CategoryPage() {
   if (status === 'pending') return <DefaultLoader />;
   if (status === 'error') return <DefaultLoader />;
 
-
   return (
     <div className="w-full h-full bg-gray-200 overflow-auto">
       <Helmet>
@@ -73,7 +134,7 @@ export function CategoryPage() {
       </Helmet>
       <Header option="titleWithBack" title={title} />
       <div className="grid gap-6pxr pb-140pxr grid-cols-card justify-center w-full">{contents}</div>
-      {isFetchingNextPage && <p className='mx-auto w-full'>로딩중</p>}
+      {isFetchingNextPage && <p className="mx-auto w-full">로딩중</p>}
     </div>
   );
 }

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -9,3 +9,4 @@ export * from './detail';
 export * from './review';
 export * from './category';
 export * from './intro';
+// export * from './todayrecipes';

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -71,7 +71,7 @@ export function MainPage() {
       <SwiperMain />
       <CategoryButtons />
       <section>
-        <Link to={'/오늘의 레시피'} className="flex pl-14pxr pr-10pxr py-10pxr text-title-2-em justify-between">
+        <Link to={'/todayrecipes'} className="flex pl-14pxr pr-10pxr py-10pxr text-title-2-em justify-between">
           <h2>오늘의 레시피</h2>
           <span className="size-30pxr bg-arrow-small-icon rotate-[270deg] bg-center"></span>
         </Link>

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -4,49 +4,51 @@ import { Link } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { ListResult, RecordModel } from 'pocketbase';
 import { SwiperMain, RecipeCard } from '@/components';
-import healthyFood from '@/assets/icons/healthy_food.png'
-import bulk from '@/assets/icons/bulk.png'
-import diet from '@/assets/icons/diet.png'
-import vegan from '@/assets/icons/vegan.png'
+import healthyFood from '@/assets/icons/healthy_food.png';
+import bulk from '@/assets/icons/bulk.png';
+import diet from '@/assets/icons/diet.png';
+import vegan from '@/assets/icons/vegan.png';
 import foodDefaultImg from '@/assets/images/flower3.jpg';
 import { Helmet } from 'react-helmet-async';
 
 const categories = [
   {
     label: '건강식',
-    image: healthyFood
+    image: healthyFood,
   },
   {
     label: '다이어트',
-    image: diet
+    image: diet,
   },
   {
     label: '벌크업',
-    image: bulk
+    image: bulk,
   },
   {
     label: '비건',
-    image: vegan
-  }
-]
+    image: vegan,
+  },
+];
 
 function CategoryButtons() {
   return (
-    <div className='w-full flex px-40pxr py-30pxr justify-between'>
-      {
-        categories.map(item => {
-          return (
-            <Link key={item.label} to={`/category/${item.label}`} className='h-74pxr w-60pxr flex flex-col items-center gap-4pxr'>
-              <div className='size-50pxr flex justify-center items-center rounded-full border hover:bg-gray-200'>
-                <img src={item.image} alt={item.label} className='size-32pxr'/>
-              </div>
-              <h2 className='text-sub'>{item.label}</h2>
-            </Link>
-          )
-        })
-      }
+    <div className="w-full flex px-40pxr py-30pxr justify-between">
+      {categories.map((item) => {
+        return (
+          <Link
+            key={item.label}
+            to={`/category/${item.label}`}
+            className="h-74pxr w-60pxr flex flex-col items-center gap-4pxr"
+          >
+            <div className="size-50pxr flex justify-center items-center rounded-full border hover:bg-gray-200">
+              <img src={item.image} alt={item.label} className="size-32pxr" />
+            </div>
+            <h2 className="text-sub">{item.label}</h2>
+          </Link>
+        );
+      })}
     </div>
-  )
+  );
 }
 
 export function MainPage() {
@@ -69,7 +71,7 @@ export function MainPage() {
       <SwiperMain />
       <CategoryButtons />
       <section>
-        <Link to={'/category/오늘의 레시피'} className="flex pl-14pxr pr-10pxr py-10pxr text-title-2-em justify-between">
+        <Link to={'/오늘의 레시피'} className="flex pl-14pxr pr-10pxr py-10pxr text-title-2-em justify-between">
           <h2>오늘의 레시피</h2>
           <span className="size-30pxr bg-arrow-small-icon rotate-[270deg] bg-center"></span>
         </Link>

--- a/src/pages/todayrecipes/TodayRecipesPage.tsx
+++ b/src/pages/todayrecipes/TodayRecipesPage.tsx
@@ -1,31 +1,68 @@
 import { db } from '@/api/pocketbase';
-import { DefaultLoader, Header, LargeCard } from '@/components';
-// import getPbImage from '@/util/data/getPBImage';
-import { useParams } from 'react-router-dom';
+import { Header, LargeCard, SkeletonLargeCard } from '@/components';
 import { Helmet } from 'react-helmet-async';
-import { useEffect, useState } from 'react';
 import { RecordModel } from 'pocketbase';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+import getPbImage from '@/util/data/getPBImage';
+
+// let rendercount = 0;
+
+const Skeleton = () => {
+  return (
+    <>
+      <SkeletonLargeCard />
+      <SkeletonLargeCard />
+    </>
+  );
+};
 
 export function TodayRecipesPage() {
-  const { title } = useParams();
   const [userData, setUserData] = useState<RecordModel>();
+  // const [isLoading, setIsLoading] = useState(true);
 
-  const getRecipeData = async () => {
+  const getRecipeData = useCallback(async () => {
     const recordsData = await db.collection('recipes').getList(1, 10, {
       expand: 'rating, profile',
       sort: '-views',
     });
     return recordsData?.items;
-  };
+  }, []);
+
+  const { data, status } = useQuery({ queryKey: ['todayrecipes'], queryFn: getRecipeData });
+  console.log(status);
+
+  const contents = data?.map((recipe, index) => {
+    const url = getPbImage('recipes', recipe.id, recipe.image);
+    return (
+      <LargeCard
+        // innerRef={ref}
+        key={index}
+        id={recipe.id}
+        userData={userData}
+        rating={recipe.expand?.rating}
+        url={recipe.image && url}
+        desc={recipe.desc}
+        title={recipe.title}
+        profile={recipe.expand?.profile}
+        keywords={recipe.keywords}
+      />
+    );
+  });
 
   useEffect(() => {
     async function getUserData() {
-      const currentUser = localStorage.getItem('pocketbase_auth');
-      if (currentUser === null) return;
-      const userId = JSON.parse(currentUser).model.id;
-      const response = await db.collection('users').getOne(userId, { requestKey: null });
-      if (response === undefined) return;
-      setUserData(response);
+      try {
+        // setIsLoading(true);
+        const currentUser = localStorage.getItem('pocketbase_auth');
+        if (currentUser === null) return;
+        const userId = JSON.parse(currentUser).model.id;
+        const response = await db.collection('users').getOne(userId, { requestKey: null });
+        if (response === undefined) return;
+        setUserData(response);
+      } finally {
+        // setIsLoading(false);
+      }
     }
 
     getUserData();
@@ -36,17 +73,29 @@ export function TodayRecipesPage() {
     };
   }, []);
 
-  if (status === 'pending') return <DefaultLoader />;
-  if (status === 'error') return <DefaultLoader />;
+  if (status === 'pending')
+    return (
+      <div className="grid gap-6pxr pb-140pxr grid-cols-card justify-center w-full">
+        <Skeleton />;
+      </div>
+    );
+
+  if (status === 'error')
+    return (
+      <div className="grid gap-6pxr pb-140pxr grid-cols-card justify-center w-full">
+        <Skeleton />;
+      </div>
+    );
+
+  // rendercount++;
 
   return (
     <div className="w-full h-full bg-gray-200 overflow-auto">
       <Helmet>
-        <title>HealthyP | {title}</title>
+        <title>HealthyP | 오늘의 레시피</title>
       </Helmet>
-      <Header option="titleWithBack" title={title} />
-      <div className="grid gap-6pxr pb-140pxr grid-cols-card justify-center w-full"></div>
-      {<p className="mx-auto w-full">로딩중</p>}
+      <Header option="titleWithBack" title={'오늘의 레시피'} />
+      <div className="grid gap-6pxr pb-140pxr grid-cols-card justify-center w-full">{contents}</div>
     </div>
   );
 }

--- a/src/pages/todayrecipes/TodayRecipesPage.tsx
+++ b/src/pages/todayrecipes/TodayRecipesPage.tsx
@@ -1,0 +1,52 @@
+import { db } from '@/api/pocketbase';
+import { DefaultLoader, Header, LargeCard } from '@/components';
+// import getPbImage from '@/util/data/getPBImage';
+import { useParams } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import { useEffect, useState } from 'react';
+import { RecordModel } from 'pocketbase';
+
+export function TodayRecipesPage() {
+  const { title } = useParams();
+  const [userData, setUserData] = useState<RecordModel>();
+
+  const getRecipeData = async () => {
+    const recordsData = await db.collection('recipes').getList(1, 10, {
+      expand: 'rating, profile',
+      sort: '-views',
+    });
+    return recordsData?.items;
+  };
+
+  useEffect(() => {
+    async function getUserData() {
+      const currentUser = localStorage.getItem('pocketbase_auth');
+      if (currentUser === null) return;
+      const userId = JSON.parse(currentUser).model.id;
+      const response = await db.collection('users').getOne(userId, { requestKey: null });
+      if (response === undefined) return;
+      setUserData(response);
+    }
+
+    getUserData();
+    db.collection('users').subscribe('*', getUserData);
+
+    return () => {
+      db.collection('users').unsubscribe();
+    };
+  }, []);
+
+  if (status === 'pending') return <DefaultLoader />;
+  if (status === 'error') return <DefaultLoader />;
+
+  return (
+    <div className="w-full h-full bg-gray-200 overflow-auto">
+      <Helmet>
+        <title>HealthyP | {title}</title>
+      </Helmet>
+      <Header option="titleWithBack" title={title} />
+      <div className="grid gap-6pxr pb-140pxr grid-cols-card justify-center w-full"></div>
+      {<p className="mx-auto w-full">로딩중</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요

- 데이터 캐시: useQuery로 데이터 캐싱
- Skeleton UI 추가: `status === pending`일때 Skeleton UI 사용 
- path 분리: category/오늘의 레시피 -> /todayrecipes로 분리

Resolves: #(Issue Number)

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 위치 수정

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
